### PR TITLE
An option to search only OS X or iOS documentation

### DIFF
--- a/Classes/OMQuickHelpPlugin.h
+++ b/Classes/OMQuickHelpPlugin.h
@@ -13,6 +13,7 @@
 {
     NSMenuItem *toggleDashItem;
     
+    NSMenuItem *searchOptionsItem;
     NSMenuItem *search_all_item;
     NSMenuItem *search_ios_item;
     NSMenuItem *search_osx_item;

--- a/Classes/OMQuickHelpPlugin.m
+++ b/Classes/OMQuickHelpPlugin.m
@@ -153,6 +153,12 @@
             
             // search options menu items
             
+            searchOptionsItem = [[[NSMenuItem alloc] initWithTitle:@"Dash Search Options"
+                                                            action:nil
+                                                     keyEquivalent:@""] retain];
+            
+            searchOptionsItem.submenu = [[NSMenu alloc] initWithTitle:@"Dash Search Options"];
+            
             search_all_item = [[[NSMenuItem alloc] initWithTitle:@"Search All Docsets"
                                                           action:@selector(toggleSearchOptions:)
                                                    keyEquivalent:@""] retain];
@@ -169,13 +175,35 @@
             search_ios_item.target = self;
             search_osx_item.target = self;
             
-            [editMenuItem.submenu addItem:[NSMenuItem separatorItem]];
-            [editMenuItem.submenu addItem:search_all_item];
-            [editMenuItem.submenu addItem:search_ios_item];
-            [editMenuItem.submenu addItem:search_osx_item];
+            [searchOptionsItem.submenu addItem:search_all_item];
+            [searchOptionsItem.submenu addItem:search_ios_item];
+            [searchOptionsItem.submenu addItem:search_osx_item];
+            
+            if(![[NSUserDefaults standardUserDefaults] boolForKey:kOMOpenInDashDisabled])
+            {
+                [self addSearchOptionsMenu];
+            }
 		}
 	}
 	return self;
+}
+
+- (void)addSearchOptionsMenu
+{
+    NSMenuItem *editMenuItem = [[NSApp mainMenu] itemWithTitle:@"Edit"];
+    
+    if(editMenuItem && !searchOptionsItem.parentItem)
+    {
+        [editMenuItem.submenu addItem:searchOptionsItem];
+    }
+}
+
+- (void)removeSearchOptionsMenu
+{
+    if(searchOptionsItem.parentItem)
+    {
+        [searchOptionsItem.parentItem.submenu removeItem:searchOptionsItem];
+    }
 }
 
 - (BOOL)validateMenuItem:(NSMenuItem *)menuItem
@@ -208,12 +236,22 @@
 - (void)toggleOpenInDashEnabled:(id)sender
 {
 	BOOL disabled = [[NSUserDefaults standardUserDefaults] boolForKey:kOMOpenInDashDisabled];
-	[[NSUserDefaults standardUserDefaults] setBool:!disabled forKey:kOMOpenInDashDisabled];
+    disabled = !disabled;
+	[[NSUserDefaults standardUserDefaults] setBool:disabled forKey:kOMOpenInDashDisabled];
+    
+    if(disabled)
+    {
+        [self removeSearchOptionsMenu];
+    }
+    else
+    {
+        [self addSearchOptionsMenu];
+    }
 }
 
 - (void)toggleSearchOptions:(NSMenuItem *)menuItem
 {
-    int searchOption;
+    int searchOption = 0;
     
     if (menuItem == search_all_item)
     {


### PR DESCRIPTION
Hi!

I use Dash for searching documentation for OS X, iOS, Ruby, Rails and CocoaPods plugins.

It bugged me that when I was working on my Mac app, alt-clicking on method names searched all the documentation, not just OSX's (it takes more time and often there's a bunch of, say, Ruby stuff I'm not interested in). Likewise, when I'm learning iOS dev, I'm usually only interested in classes and methods from iOS docset.

So I changed your awesome plugin a little bit and added an option in Edit menu to only search in OS X or iOS docsets:

![Zrzut ekranu 2013-01-16 o 11 08 12](https://f.cloud.github.com/assets/183747/70852/9559d898-5fc5-11e2-8165-9e74dc6d4a3c.png)

I think more people use Dash that way and would find it useful to only search a certain docset.
