### PR TITLE
Fixes Xcode Quick Help → Dash not working when offline

### DIFF
--- a/Classes/OMQuickHelpPlugin.m
+++ b/Classes/OMQuickHelpPlugin.m
@@ -89,13 +89,11 @@
 {
 	if (searchString.length == 0) {
 		NSBeep();
-	} else {
-		BOOL opened = [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:[NSString stringWithFormat:@"dash://%@", searchString]]];
-		if (!opened) {
-			return NO;
-		}
+		return NO;
 	}
-	return YES;
+	NSPasteboard *pboard = [NSPasteboard pasteboardWithUniqueName];
+	[pboard setString:searchString forType:NSStringPboardType];
+	return NSPerformService(@"Look Up in Dash", pboard);
 }
 
 @end


### PR DESCRIPTION
Uses `NSPerformService()` instead of calling `-[NSWorkspace openURL:]` to allow Quick Help to work without active network interfaces.

**Tested on:** OS X 10.8.3 (12D76), Xcode 4.6 (4H127), Dash 1.8.0
**Reference:** https://github.com/omz/Dash-Plugin-for-Xcode/issues/2
