### PR TITLE
Keyword finding bug

### DIFF
--- a/Classes/OMQuickHelpPlugin.m
+++ b/Classes/OMQuickHelpPlugin.m
@@ -160,7 +160,7 @@
                     if(found)
                     {
                         NSString *keyword = [docset objectForKey:@"keyword"];
-                        foundKeyword = (keyword) ? keyword : platform;
+                        foundKeyword = (keyword && keyword.length) ? keyword : platform;
                         break;
                     }
                 }


### PR DESCRIPTION
Fixes a bug which occurs when you have previously had a custom keyword set, but have removed it at some point. This tricks the plugin into thinking there is a custom keyword when there actually is none.
