### PR TITLE
Platform detection disabled by default

### DIFF
--- a/Classes/OMQuickHelpPlugin.m
+++ b/Classes/OMQuickHelpPlugin.m
@@ -11,7 +11,7 @@
 
 #define kOMSuppressDashNotInstalledWarning	@"OMSuppressDashNotInstalledWarning"
 #define kOMOpenInDashDisabled				@"OMOpenInDashDisabled"
-#define kOMDashPlatformDetectionDisabled    @"OMDashPlatformDetectionDisabled"
+#define kOMDashPlatformDetectionEnabled    @"OMDashPlatformDetectionEnabled"
 
 @interface NSObject (OMSwizzledIDESourceCodeEditor)
 
@@ -110,7 +110,7 @@
 
 - (NSString *)om_appendActiveSchemeKeyword:(NSString *)searchString
 {
-    if(![[NSUserDefaults standardUserDefaults] boolForKey:kOMDashPlatformDetectionDisabled])
+    if([[NSUserDefaults standardUserDefaults] boolForKey:kOMDashPlatformDetectionEnabled])
     {
         @try { // I don't trust myself with this swizzling business
             id windowController = [[NSApp keyWindow] windowController];
@@ -229,10 +229,10 @@
 		}
 	}
     else if([menuItem action] == @selector(toggleDashPlatformDetection:)) {
-		if ([[NSUserDefaults standardUserDefaults] boolForKey:kOMDashPlatformDetectionDisabled]) {
-			[menuItem setState:NSOffState];
-		} else {
+		if ([[NSUserDefaults standardUserDefaults] boolForKey:kOMDashPlatformDetectionEnabled]) {
 			[menuItem setState:NSOnState];
+		} else {
+			[menuItem setState:NSOffState];
 		}
 	}
 	return YES;
@@ -246,8 +246,8 @@
 
 - (void)toggleDashPlatformDetection:(id)sender
 {
-    BOOL disabled = [[NSUserDefaults standardUserDefaults] boolForKey:kOMDashPlatformDetectionDisabled];
-	[[NSUserDefaults standardUserDefaults] setBool:!disabled forKey:kOMDashPlatformDetectionDisabled];
+    BOOL enabled = [[NSUserDefaults standardUserDefaults] boolForKey:kOMDashPlatformDetectionEnabled];
+	[[NSUserDefaults standardUserDefaults] setBool:!enabled forKey:kOMDashPlatformDetectionEnabled];
 }
 
 @end

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ I'm [@olemoritz](http://twitter.com/olemoritz) on Twitter.
 1. Download the source, build the Xcode project and restart Xcode. The plugin will automatically be installed in `~/Library/Application Support/Developer/Shared/Xcode/Plug-ins`. To uninstall, just remove the plugin from there (and restart Xcode).
 2. To use - **Option-Click** any method/class/symbol in Xcode's text editor.
 
+## Automatic Platform Detection
+The plugin can use Xcode's current active scheme to determine which docset to search (iOS or OS X). Using this feature, ONLY the iOS or OS X docsets will be searched, so you might not want this if, for example, you also want to search the Cocos2D docset.
+
+To enable automatic platform detection, go to Edit > Dash Integration > Enable Dash Platform Detection in Xcode's menu (after you installed the plugin).
+
 ## License
 
     Copyright (c) 2012, Ole Zorn


### PR DESCRIPTION
Some users are confused by the platform detection. For example, if they have the Cocos2D docset and ALT+Click on something Cocos2D, the plugin causes Dash to ignore the Cocos2D docset. This is even worse considering that third-party docsets are becoming quite popular (e.g. cocoadocs.org), as all other docsets except iOS or OS X would be ignored.

While platform detection is useful sometimes, I think it's best to avoid confusion and have it disabled by default, at least until there's a way of getting it to work reliably.
