### PR TITLE
Get selected symbol correctly when code is folded

### DIFF
--- a/Classes/OMQuickHelpPlugin.m
+++ b/Classes/OMQuickHelpPlugin.m
@@ -15,7 +15,6 @@
 
 @interface NSObject (OMSwizzledIDESourceCodeEditor)
 
-- (void)om_textView:(id)arg1 didClickOnTemporaryLinkAtCharacterIndex:(unsigned long long)arg2 event:(id)arg3 isAltEvent:(BOOL)arg4;
 - (void)om_showQuickHelp:(id)sender;
 - (void)om_dashNotInstalledFallback;
 - (BOOL)om_showQuickHelpForSearchString:(NSString *)searchString;
@@ -64,39 +63,6 @@
 		if ([[alert suppressionButton] state] == NSOnState) {
 			[[NSUserDefaults standardUserDefaults] setBool:YES forKey:kOMSuppressDashNotInstalledWarning];
 		}
-	}
-}
-
-- (void)om_textView:(NSTextView *)textView didClickOnTemporaryLinkAtCharacterIndex:(unsigned long long)charIndex event:(NSEvent *)event isAltEvent:(BOOL)isAltEvent
-{
-	BOOL dashDisabled = [[NSUserDefaults standardUserDefaults] boolForKey:kOMOpenInDashDisabled];
-	if (isAltEvent && !dashDisabled) {
-		@try {
-			NSArray *linkRanges = [textView valueForKey:@"_temporaryLinkRanges"];
-			NSMutableString *searchString = [NSMutableString string];
-			for (NSValue *rangeValue in linkRanges) {
-				NSRange range = [rangeValue rangeValue];
-				NSString *stringFromRange = [textView.textStorage.string substringWithRange:range];
-				[searchString appendString:stringFromRange];
-			}
-            if(searchString.length)
-            {
-                BOOL dashOpened = [self om_showQuickHelpForSearchString:searchString];
-                if (!dashOpened) {
-                    [self om_dashNotInstalledFallback];
-                }
-            }
-            else
-            {
-                NSBeep();
-            }
-		}
-		@catch (NSException *exception) {
-			
-		}
-	} else {
-		//Preserve the default behavior for cmd-clicks:
-		[self om_textView:textView didClickOnTemporaryLinkAtCharacterIndex:charIndex event:event isAltEvent:isAltEvent];
 	}
 }
 
@@ -192,7 +158,6 @@
 	dispatch_once(&onceToken, ^{
 		if (NSClassFromString(@"IDESourceCodeEditor") != NULL) {
 			[NSClassFromString(@"IDESourceCodeEditor") jr_swizzleMethod:@selector(showQuickHelp:) withMethod:@selector(om_showQuickHelp:) error:NULL];
-			[NSClassFromString(@"IDESourceCodeEditor") jr_swizzleMethod:@selector(textView:didClickOnTemporaryLinkAtCharacterIndex:event:isAltEvent:) withMethod:@selector(om_textView:didClickOnTemporaryLinkAtCharacterIndex:event:isAltEvent:) error:NULL];
 		}
 		[[self alloc] init];
 	});


### PR DESCRIPTION
This is related to https://github.com/omz/Dash-Plugin-for-Xcode/issues/7#issuecomment-20673109.

What happens is that if the user has code folded somewhere above the place he ALT+Clicks, the string range does not match. I think that Xcode does something funny with its string storage when it's folding code and `_temporaryLinkRanges` no longer gives the correct string ranges.

This bug only occurs on ALT+Click and not when the "Quick Help with Selected Item" menu item is called (`om_showQuickHelp:`). What I did to fix the bug was to stop swizzling `textView:didClickOnTemporaryLinkAtCharacterIndex:event:isAltEvent:` completely.

Question: did you have a reason for swizzling `textView:didClickOnTemporaryLinkAtCharacterIndex:event:isAltEvent:`? It seems to work perfectly fine without it, as in Xcode just forwards the ALT+Click to `om_showQuickHelp:`.
